### PR TITLE
Missing rte_kni_init() call

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,10 @@ Legend:
 Change log
 ==========
 
+v0.7.1
+
+[B][gnu-linux-dpdk] Fixing missing call to rte_kni_init() (introduced in 0aa54f09)
+
 v0.7.0
 
 [+] New build system. Now ROFL dependencies and, if necessary, DPDK, are compiled on board

--- a/src/xdpd/drivers/gnu_linux_dpdk/src/hal-imp/nf_extensions.cc
+++ b/src/xdpd/drivers/gnu_linux_dpdk/src/hal-imp/nf_extensions.cc
@@ -13,18 +13,13 @@
 
 using namespace xdpd::gnu_linux;
 
-#if defined(DPDK_PATCHED_KNI)
 static bool kni_inited = false;
-#endif //DPDK_PATCHED_KNI
 
-hal_result_t hal_driver_dpdk_nf_create_nf_port(const char *nf_name, const char *nf_port_name, port_type_t nf_port_type)
-{
+hal_result_t hal_driver_dpdk_nf_create_nf_port(const char *nf_name, const char *nf_port_name, port_type_t nf_port_type){
+
 	if((nf_port_type != PORT_TYPE_NF_SHMEM) && (nf_port_type != PORT_TYPE_NF_EXTERNAL))
-	{
 		return HAL_FAILURE;
-	}
 
-#if defined(DPDK_PATCHED_KNI)
 	//TODO: rte_kni_init() should be moved back to hal_driver_init(), but
 	//for that the DPDK KNI kernel module should take into account that 
 	//the number of KNI interfaces to bootstrap the kthread/s 
@@ -34,24 +29,19 @@ hal_result_t hal_driver_dpdk_nf_create_nf_port(const char *nf_name, const char *
 		rte_kni_init(GNU_LINUX_DPDK_MAX_KNI_IFACES);
 		kni_inited = true;
 	}
-#endif
 
 	//create the port and initialize the structure for the pipeline
 	if(iface_manager_create_nf_port(nf_name, nf_port_name, nf_port_type) != ROFL_SUCCESS)
-	{
 		return HAL_FAILURE;
-	}
-	
+
 	return HAL_SUCCESS;
 }
 
-hal_result_t hal_driver_dpdk_nf_destroy_nf_port(const char *nf_port_name)
-{
+hal_result_t hal_driver_dpdk_nf_destroy_nf_port(const char *nf_port_name){
+
 	//create the port and initialize the structure for the pipeline
 	if(iface_manager_destroy_nf_port(nf_port_name) != ROFL_SUCCESS)
-	{
 		return HAL_FAILURE;
-	}
 
 	return HAL_SUCCESS;
 }


### PR DESCRIPTION
Fixing bug introduced in commit 0aa54f0 when removing the routines
checking for a patched DPDK with KNI memzone pool patch and defining
`DPDK_PATCHED_KNI`
