### PR TITLE
Fixing RX/TX dpdk PHY port stats

### DIFF
--- a/src/xdpd/drivers/gnu_linux_dpdk/src/config.h
+++ b/src/xdpd/drivers/gnu_linux_dpdk/src/config.h
@@ -32,7 +32,7 @@
 #define BG_UPDATE_PORT_LINKS_MS 400
 
 //Frequency(period) of port stats updating in milliseconds
-#define BG_UPDATE_PORT_STATS_MS 2000
+#define BG_UPDATE_PORT_STATS_MS 500
 
 //Frequency(period) of handling KNI commands in milliseconds
 #define BG_HANDLE_KNI_COMMANDS_MS 1000

--- a/src/xdpd/drivers/gnu_linux_dpdk/src/io/iface_manager.cc
+++ b/src/xdpd/drivers/gnu_linux_dpdk/src/io/iface_manager.cc
@@ -560,36 +560,38 @@ void iface_manager_update_links(){
 * Update port stats (pipeline)
 */
 void iface_manager_update_stats(){
-	
+
 	unsigned int i, j;
 	struct rte_eth_stats stats;
 	switch_port_t* port;
-	
-	for(i=0;i<PORT_MANAGER_MAX_PORTS;i++){
+
+	for(i=0; i<PORT_MANAGER_MAX_PORTS; ++i){
+
 		port = phy_port_mapping[i];
-		if(unlikely(port != NULL)){
 
-			//Retrieve stats
-			rte_eth_stats_get(i, &stats);
-			
-			//RX	
-			port->stats.rx_packets = stats.ipackets;
-			port->stats.rx_bytes = stats.ibytes;
-			port->stats.rx_errors = stats.ierrors;
-				
-			//FIXME: collisions and other errors
-		
-			//TX
-			port->stats.tx_packets = stats.opackets;
-			port->stats.tx_bytes = stats.obytes;
-			port->stats.tx_errors = stats.oerrors;
+		if(!port)
+			continue;
 
-			//TX-queues
-			for(j=0;j<IO_IFACE_NUM_QUEUES;j++){
-				port->queues[j].stats.tx_packets = stats.q_opackets[j];
-				port->queues[j].stats.tx_bytes = stats.q_obytes[j];
-				//port->queues[j].stats.overrun = stats.q_;
-			}
+		//Retrieve stats
+		rte_eth_stats_get(i, &stats);
+
+		//RX
+		port->stats.rx_packets = stats.ipackets;
+		port->stats.rx_bytes = stats.ibytes;
+		port->stats.rx_errors = stats.ierrors;
+
+		//FIXME: collisions and other errors
+
+		//TX
+		port->stats.tx_packets = stats.opackets;
+		port->stats.tx_bytes = stats.obytes;
+		port->stats.tx_errors = stats.oerrors;
+
+		//TX-queues
+		for(j=0; j<IO_IFACE_NUM_QUEUES; ++j){
+			port->queues[j].stats.tx_packets = stats.q_opackets[j];
+			port->queues[j].stats.tx_bytes = stats.q_obytes[j];
+			//port->queues[j].stats.overrun = stats.q_;
 		}
 	}
 

--- a/src/xdpd/drivers/gnu_linux_dpdk/src/io/rx.h
+++ b/src/xdpd/drivers/gnu_linux_dpdk/src/io/rx.h
@@ -115,8 +115,12 @@ process_port_rx(unsigned int core_id, switch_port_t* port, struct rte_mbuf** pkt
 		pkt_state->mbuf = mbuf;
 
 		//Increment port RX statistics
-		port->stats.rx_packets++;
-		port->stats.rx_bytes += mbuf->pkt.pkt_len;
+#ifdef GNU_LINUX_DPDK_ENABLE_NF
+		if(port->type != PORT_TYPE_PHYSICAL){
+			port->stats.rx_packets++;
+			port->stats.rx_bytes += mbuf->pkt.pkt_len;
+		}
+#endif
 
 		//We only support nb_segs == 1. TODO: can it be that NICs send us pkts with more than one segment?
 		assert(mbuf->pkt.nb_segs == 1);

--- a/src/xdpd/drivers/gnu_linux_dpdk/src/io/tx.h
+++ b/src/xdpd/drivers/gnu_linux_dpdk/src/io/tx.h
@@ -33,7 +33,7 @@ namespace gnu_linux_dpdk {
 inline void
 transmit_port_queue_tx_burst(unsigned int port_id, unsigned int queue_id, struct rte_mbuf** burst){
 	
-	unsigned int ret, len, i, tx_bytes;
+	unsigned int ret, len;
 	switch_port_t* port = phy_port_mapping[port_id];
 
 	//Dequeue a burst from the TX ring	
@@ -44,19 +44,8 @@ transmit_port_queue_tx_burst(unsigned int port_id, unsigned int queue_id, struct
  
 	ROFL_DEBUG_VERBOSE(DRIVER_NAME"[io][%s(%u)] Trying to transmit burst on port queue_id %u of length %u\n", phy_port_mapping[port_id]->name,  port_id, queue_id, len);
 
-	//Calculate tx bytes
-	for(i=0, tx_bytes=0;i<len;++i){
-		tx_bytes += burst[i]->pkt.pkt_len;
-	}
-
 	//Send burst
 	ret = rte_eth_tx_burst(port_id, queue_id, burst, len);
-	
-	//Increment port stats
-	port->stats.tx_packets += (len-ret);
-	port->stats.tx_bytes += tx_bytes;
-	port->queues[queue_id].stats.tx_packets += (len-ret);
-	port->queues[queue_id].stats.tx_bytes += tx_bytes;
 
 	ROFL_DEBUG_VERBOSE(DRIVER_NAME"[io][%s(%u)] +++ Transmited %u pkts, on queue_id %u\n", phy_port_mapping[port_id]->name, port_id, ret, queue_id);
 
@@ -64,15 +53,8 @@ transmit_port_queue_tx_burst(unsigned int port_id, unsigned int queue_id, struct
 		//Increment errors
 		port->stats.tx_dropped += ret;
 		port->queues[queue_id].stats.overrun += ret;
-			
+
 		do {
-			//Remove the stats not 
-			//unfortunately there is no other way of efficiently do so
-			//since the rte_eth_tx_burst() does not return the amount of bytes
-			//TXed	
-			port->stats.tx_bytes -= burst[ret]->pkt.pkt_len ;
-			port->queues[queue_id].stats.tx_bytes -= burst[ret]->pkt.pkt_len;
-		
 			//Now release the mbuf
 			rte_pktmbuf_free(burst[ret]);
 		} while (++ret < len);


### PR DESCRIPTION
Port statistics, for both RX and TX, were corrupted due to the
unnecessary (non-atomic) increment done by the I/O cores, which was
anyway double accounted and removed during iface_manager_update_stats()
- Remove unnecessary RX/TX stats inc for physical ports
- Reduced port stats update interval, BG_UPDATE_PORT_STATS_MS, to 500ms
