### PR TITLE
Fix build pipeline lockless and inline

### DIFF
--- a/config/hw.m4
+++ b/config/hw.m4
@@ -91,6 +91,10 @@ fi
 #Print fancy message
 AC_MSG_RESULT($msg)
 
+#Print a nice message
+AC_MSG_CHECKING(whether driver supports rofl-pipeline inlining...)
+AC_MSG_RESULT($DRIVER_HAS_INLINE_SUPPORT)
+
 AM_CONDITIONAL([DRIVER_HAS_INLINE_SUPPORT], [test "$DRIVER_HAS_INLINE_SUPPORT" = "yes"])
 AM_CONDITIONAL([WITH_DPDK], [test "$WITH_DPDK" = "yes"])
 AC_SUBST(PLATFORM)

--- a/libs/Makefile.am
+++ b/libs/Makefile.am
@@ -96,7 +96,7 @@ rofl-datapath:
 		cd $(LIBS_BUILD_DIR)/$$LIB/build || exit -1 ;					\
 		CFLAGS="$(LIBS_CFLAGS)" CXXFLAGS="$(LIBS_CXXFLAGS)" LDFLAGS="$(LIBS_LDFLAGS)" 	\
 		CPPFLAGS="$(LIBS_CPPFLAGS)" CC="$(CC)" CXX="$(CXX)" 				\
-		$(LIBS_DIR)/$$LIB/configure $(ROFL_CM_AC_FLAGS) || exit -1 ; 			\
+		$(LIBS_DIR)/$$LIB/configure $(ROFL_DP_AC_FLAGS) || exit -1 ; 			\
 		$(MAKE) || exit -1 ; 								\
 		cd $$OLD_PWD || exit -1 ;							\
 		touch $(RD_COMMIT_FILE) || exit -1 ; 						\


### PR DESCRIPTION
Due to a copy&paste mistake, configure time lockless and inline flags
were not passed to rofl-pipeline, causing substantial performance
degradation ~40%.
