### PR TITLE
Fix several build system issues (bis)

### DIFF
--- a/config/pipeline_opts.m4
+++ b/config/pipeline_opts.m4
@@ -1,0 +1,14 @@
+#Pipeline optimizations
+
+AC_MSG_CHECKING(if user overrides default rofl-pipeline optimizations...)
+
+#Detect if user is overriding our defaults
+if test -z "`echo $AC_CONFIGURE_ARGS |  sed -e 's/--with\(out\)*-pipeline/USER_PIPELINE_CTL/' | grep USER_PIPELINE_CTL`"; then
+	USER_OVERRIDES_PIPELINE_FLAGS="no"
+	AC_MSG_RESULT([no])
+else
+	USER_OVERRIDES_PIPELINE_FLAGS="yes"
+	AC_MSG_RESULT([yes])
+fi
+
+AM_CONDITIONAL([USER_OVERRIDES_PIPELINE_FLAGS], [test "$USER_OVERRIDES_PIPELINE_FLAGS" = "yes"])

--- a/configure.ac
+++ b/configure.ac
@@ -71,6 +71,9 @@ m4_include([config/profiling.m4])
 #Experimental code
 m4_include([config/experimental.m4])
 
+#Pipeline optimizations
+m4_include([config/pipeline_opts.m4])
+
 #External libraries
 m4_include([config/libs.m4])
 

--- a/libs/Makefile.am
+++ b/libs/Makefile.am
@@ -68,11 +68,13 @@ maintainer-clean-rofl-common: clean-rofl-common
 ##
 
 #Defaults
-ROFL_DP_AC_FLAGS=$(AC_CONFIGURE_ARGS)
-
+ROFL_DP_AC_FLAGS=""
 if DRIVER_HAS_INLINE_SUPPORT
+if !USER_OVERRIDES_PIPELINE_FLAGS
 ROFL_DP_AC_FLAGS+= --with-pipeline-lockless --with-pipeline-platform-funcs-inlined
 endif
+endif
+ROFL_DP_AC_FLAGS+=$(AC_CONFIGURE_ARGS)
 
 #Makefile specific variables (at automake time)
 RD_COMMIT_FILE=$(LIBS_BUILD_DIR)/.rofl-datapath-commit

--- a/libs/Makefile.am
+++ b/libs/Makefile.am
@@ -171,3 +171,5 @@ all: rofl-common rofl-datapath
 clean-libs: clean-rofl-common clean-rofl-common-datapath
 maintainer-clean-local: maintainer-clean-rofl-common maintainer-clean-rofl-datapath
 endif
+
+check: all


### PR DESCRIPTION
Follow-up of #80 

Confirmed the issue with both `without` clauses, but this is not a problem of the build system of xdpd but of rofl-datapath. Nevertheless let's wait for fixing the latter.
