### PR TITLE
add missing dependency for xmpclient

### DIFF
--- a/src/xdpd/management/plugins/xmp/Makefile.am
+++ b/src/xdpd/management/plugins/xmp/Makefile.am
@@ -68,7 +68,8 @@ xmpclient_SOURCES = \
 
 xmpclient_LDADD = libxdpd_xmp_client.la \
 	libxdpd_mgmt_xmp.la \
-	libxdpd_xmp.la
+	libxdpd_xmp.la \
+	-lrofl_common
 
 
 pkgconfigdir = $(libdir)/pkgconfig


### PR DESCRIPTION
this commit fixes the build for xmpclient
