### PR TITLE
REST management of controllers

### DIFF
--- a/src/xdpd/management/plugins/config/openflow/lsi_scope.cc
+++ b/src/xdpd/management/plugins/config/openflow/lsi_scope.cc
@@ -294,7 +294,7 @@ void lsi_scope::post_validate(libconfig::Setting& setting, bool dry_run){
 		
 		//Connect(1..N-1)
 		for(std::vector<lsi_connection>::iterator it = (conns.begin()+1); it != conns.end(); ++it) {
-			switch_manager::rpc_connect_to_ctl(dpid, it->type, it->params); 
+			switch_manager::connect_to_ctl(dpid, it->type, it->params); 
 		}	
 	}
 }

--- a/src/xdpd/management/plugins/rest/delete-controllers.h
+++ b/src/xdpd/management/plugins/rest/delete-controllers.h
@@ -12,6 +12,7 @@ namespace delete_{
 	* Destroy an LSI
 	*/
 	void destroy_switch(const http::server::request &, http::server::reply &, boost::cmatch&);
+	void rem_ctl(const http::server::request &, http::server::reply &, boost::cmatch&);
 
 } //namespace delete_
 } //namespace controllers

--- a/src/xdpd/management/plugins/rest/get-controllers.h
+++ b/src/xdpd/management/plugins/rest/get-controllers.h
@@ -35,6 +35,12 @@ namespace get{
 	void list_ports(const http::server::request &, http::server::reply &, boost::cmatch&);
 	void port_detail(const http::server::request &, http::server::reply &, boost::cmatch&);
 
+	/**
+	 * Controllers
+	 */
+	void list_ctls(const http::server::request &, http::server::reply &, boost::cmatch&);
+	void show_ctl(const http::server::request &, http::server::reply &, boost::cmatch&);
+
 } //namespace get
 } //namespace controllers
 } //namespace xdpd

--- a/src/xdpd/management/plugins/rest/put-controllers.h
+++ b/src/xdpd/management/plugins/rest/put-controllers.h
@@ -17,6 +17,11 @@ namespace put{
 	* Create a vlink
 	*/
 	void create_vlink(const http::server::request &, http::server::reply &, boost::cmatch&);
+	
+	/*
+	* Add a new controller to the LSI
+	*/
+	void add_ctl(const http::server::request &, http::server::reply &, boost::cmatch&);	
 
 } //namespace put
 } //namespace controllers

--- a/src/xdpd/management/plugins/rest/rest.cc
+++ b/src/xdpd/management/plugins/rest/rest.cc
@@ -103,7 +103,7 @@ static void srvthread (){
 		// CONTROLLERS
 		//
 		handler.register_put_path("/mgmt/add/controller/(\\w+)", boost::bind(controllers::put::add_ctl, _1, _2, _3));
-		// delete ctl
+		handler.register_delete_path("/mgmt/remove/controller/(\\w+)/(\\w+)", boost::bind(controllers::delete_::rem_ctl, _1, _2, _3));
 		// list ctls
 
 		//

--- a/src/xdpd/management/plugins/rest/rest.cc
+++ b/src/xdpd/management/plugins/rest/rest.cc
@@ -104,8 +104,8 @@ static void srvthread (){
 		//
 		handler.register_put_path("/mgmt/add/controller/(\\w+)", boost::bind(controllers::put::add_ctl, _1, _2, _3));
 		handler.register_delete_path("/mgmt/remove/controller/(\\w+)/(\\w+)", boost::bind(controllers::delete_::rem_ctl, _1, _2, _3));
-		handler.register_get_path("/info/lsi/(\\w+)/ctls", boost::bind(controllers::get::list_ctls, _1, _2, _3));
-		handler.register_get_path("/info/lsi/(\\w+)/ctl/(\\w+)", boost::bind(controllers::get::show_ctl, _1, _2, _3));
+		handler.register_get_path("/info/lsi/(\\w+)/controllers", boost::bind(controllers::get::list_ctls, _1, _2, _3));
+		handler.register_get_path("/info/lsi/(\\w+)/controller/(\\w+)", boost::bind(controllers::get::show_ctl, _1, _2, _3));
 
 		//
 		//DELETE

--- a/src/xdpd/management/plugins/rest/rest.cc
+++ b/src/xdpd/management/plugins/rest/rest.cc
@@ -100,6 +100,13 @@ static void srvthread (){
 		handler.register_put_path("/mgmt/create/vlink/(\\w+)/(\\w+)", boost::bind(controllers::put::create_vlink, _1, _2, _3));
 
 		//
+		// CONTROLLERS
+		//
+		handler.register_put_path("/mgmt/add/controller/(\\w+)", boost::bind(controllers::put::add_ctl, _1, _2, _3));
+		// delete ctl
+		// list ctls
+
+		//
 		//DELETE
 		//
 		handler.register_delete_path("/mgmt/destroy/lsi/(\\w+)", boost::bind(controllers::delete_::destroy_switch, _1, _2, _3));

--- a/src/xdpd/management/plugins/rest/rest.cc
+++ b/src/xdpd/management/plugins/rest/rest.cc
@@ -104,7 +104,8 @@ static void srvthread (){
 		//
 		handler.register_put_path("/mgmt/add/controller/(\\w+)", boost::bind(controllers::put::add_ctl, _1, _2, _3));
 		handler.register_delete_path("/mgmt/remove/controller/(\\w+)/(\\w+)", boost::bind(controllers::delete_::rem_ctl, _1, _2, _3));
-		// list ctls
+		handler.register_get_path("/info/lsi/(\\w+)/ctls", boost::bind(controllers::get::list_ctls, _1, _2, _3));
+		handler.register_get_path("/info/lsi/(\\w+)/ctl/(\\w+)", boost::bind(controllers::get::show_ctl, _1, _2, _3));
 
 		//
 		//DELETE

--- a/src/xdpd/management/plugins/rest/sw-controllers.cc
+++ b/src/xdpd/management/plugins/rest/sw-controllers.cc
@@ -260,7 +260,7 @@ void list_ctls(const http::server::request &req, http::server::reply &rep, boost
 	
 	try{
 		ss<<"Listing controllers from: " << lsi_name;
-		switch_manager::rpc_list_ctls(dpid, &list);
+		switch_manager::list_ctls(dpid, &list);
 	}catch(...){
 		ss<<"Unable to get list of ctls from lsi '"<<lsi_name<<"'";
 		rep.content = ss.str();
@@ -532,7 +532,7 @@ void add_ctl(const http::server::request &req, http::server::reply &rep, boost::
 
 	try{
 		ss<<"Adding Controller: " << lsi_name << " : " << proto;
-		assigned_id = switch_manager::rpc_connect_to_ctl(dpid, socket_type, socket_params);
+		assigned_id = switch_manager::connect_to_ctl(dpid, socket_type, socket_params);
 	}catch(...){
 		//Something went wrong
                 ss<<"Unable to add controller to lsi '"<<lsi_name<<"'";
@@ -615,7 +615,7 @@ void rem_ctl(const http::server::request &req, http::server::reply &rep, boost::
 
 	try{
 		ss<<"Removing Controller: " << lsi_name << " : " << ctlid_str;
-		switch_manager::rpc_disconnect_from_ctl(dpid, ctlid);
+		switch_manager::disconnect_from_ctl(dpid, ctlid);
 	}catch(...){
 		//Something went wrong
                 std::stringstream ss;

--- a/src/xdpd/management/plugins/rest/sw-controllers.cc
+++ b/src/xdpd/management/plugins/rest/sw-controllers.cc
@@ -277,7 +277,7 @@ void list_ctls(const http::server::request &req, http::server::reply &rep, boost
 	}
 
 	json_spirit::Value ids_(list_str.begin(), list_str.end());
-	table.push_back(json_spirit::Pair("ids", ids_));
+	table.push_back(json_spirit::Pair("controller-ids", ids_));
 	rep.content = json_spirit::write(table, true);
 }
 

--- a/src/xdpd/management/plugins/rest/sw-controllers.cc
+++ b/src/xdpd/management/plugins/rest/sw-controllers.cc
@@ -236,6 +236,14 @@ void lsi_groups(const http::server::request &req,
 	rep.content = json_spirit::write(wrap, true);
 }
 
+void list_ctls(const http::server::request &req, http::server::reply &rep, boost::cmatch& grps){
+	fprintf(stderr,"LIST CONTROLLERS CALLED\n");
+}
+
+void show_ctl(const http::server::request &req, http::server::reply &rep, boost::cmatch& grps){
+	fprintf(stderr,"SHOW CONTROLLER CALLED\n");
+}
+
 } //namespace get
 
 

--- a/src/xdpd/management/plugins/rest/sw-controllers.cc
+++ b/src/xdpd/management/plugins/rest/sw-controllers.cc
@@ -517,13 +517,11 @@ void add_ctl(const http::server::request &req, http::server::reply &rep, boost::
 	}
 
 
-	//fprintf(stderr,"found proto: %s\n ip %s\n port %s\n", proto.c_str(), ip.c_str(), port.c_str());
 	//TODO Check parameters received (proto, ip & port)
 	if ( proto == "tcp" ){
 		socket_type = rofl::csocket::SOCKET_TYPE_PLAIN;
 	} else {
-		//Other types not supported
-		// TODO add SOCKET_TYPE_OPENSSL
+		// TODO Other types not yet  supported (SOCKET_TYPE_OPENSSL)
 		return;
 	}
 	socket_params = rofl::csocket::get_default_params(socket_type);

--- a/src/xdpd/management/plugins/rest/sw-controllers.cc
+++ b/src/xdpd/management/plugins/rest/sw-controllers.cc
@@ -456,7 +456,8 @@ void add_ctl(const http::server::request &req, http::server::reply &rep, boost::
 	std::string proto, ip, port;
 	enum rofl::csocket::socket_type_t socket_type;
 	rofl::cparams socket_params;
-	//json_spirit::Object table;
+	json_spirit::Object table;
+	uint64_t assigned_id;
 	
 	//Perform security checks
         if(!authorised(req,rep)) return;
@@ -516,8 +517,7 @@ void add_ctl(const http::server::request &req, http::server::reply &rep, boost::
 
 	try{
 		ss<<"Adding Controller: " << lsi_name << " : " << proto;
-		//uint64_t id = switch_manager::rpc_connect_to_ctl(dpid, socket_type, socket_params);
-		switch_manager::rpc_connect_to_ctl(dpid, socket_type, socket_params);
+		assigned_id = switch_manager::rpc_connect_to_ctl(dpid, socket_type, socket_params);
 	}catch(...){
 		//Something went wrong
                 ss<<"Unable to add controller to lsi '"<<lsi_name<<"'";
@@ -527,8 +527,8 @@ void add_ctl(const http::server::request &req, http::server::reply &rep, boost::
 	}
 	
 	//Return assigned ID
-	//table.push_back(json_spirit::Pair("assigned id", id));
-	//rep.content = json_spirit::write(table, true);
+	table.push_back(json_spirit::Pair("assigned id", assigned_id));
+	rep.content = json_spirit::write(table, true);
 }
 
 } //namespace put

--- a/src/xdpd/management/plugins/rest/xcli
+++ b/src/xdpd/management/plugins/rest/xcli
@@ -57,6 +57,7 @@ def list_exec_commands():
 	string+='   exec destroy lsi <lsi_name> \t\t\t - Destroy a logical switch instance\n'
 	string+='   exec create vlink <lsi1_name> <lsi2_name>\t - Create a virtual link between two logical switch instances\n'
 	string+='   exec add controller <lsi_name> <mode:ip:port>\n'
+	string+='   exec remove controller <lsi_name> <ctl_id>\n'
 	string+="\nExamples:\n\n"
 	string+='   exec port ge0 up\n'
 	string+='   exec attach port ge0 dp0\n'
@@ -344,14 +345,14 @@ def execute(socket, command, req_confirm=False):
 				except Exception as e:	
 					return "error: "+str(e)
 			else:
-				return "Usage: exec add controller ..."
+				return "Usage: exec add controller <params>"
 
 		elif "remove" in command:
 			data = ""
 			if "controller" in command:
-                                return rest(socket. compose_url(stripped), data, "PUT")
+                                return rest(socket, compose_url(stripped), data, "DELETE")
                         else:
-                                return "Usage: exec remove controller ..."
+                                return "Usage: exec remove controller <id>"
 
 		else:
 			return rest(socket, compose_url(stripped), "", "POST")
@@ -529,7 +530,7 @@ class InteractivePrompt(cmd.Cmd):
 			print_less(result)
 
 	def complete_exec(self, text, line, start_index, end_index):
-		exec_cmds = ["port", "attach", "detach", "create", "destroy", "add", "remove"]
+		exec_cmds = ["port", "attach", "detach", "create", "destroy", "add controller", "remove controller"]
 
 		for cmd in exec_cmds:
 			if cmd in line:

--- a/src/xdpd/management/plugins/rest/xcli
+++ b/src/xdpd/management/plugins/rest/xcli
@@ -42,6 +42,8 @@ def list_show_commands():
 	string+= '   show lsi <lsi_name>\t\t\t - Show LSI information\n'
 	string+= '   show lsi <lsi_name> table <num> flows - Show LSI table <num> flows\n'
 	string+= '   show lsi <lsi_name> group-table\t - List LSI group-table entries\n'
+	string+= '   show lsi <lsi_name> ctls\t - List IDs of LSI\'s Controllers\n'
+	string+= '   show lsi <lsi_name> ctl <ctl-id>\t - Show Controller information\n'
 	string+= '   show ports\t\t\t\t - List the available ports in the platform\n'
 	string+= '   show port <port_name>\t\t - Show port information\n'
 	return string

--- a/src/xdpd/management/plugins/rest/xcli
+++ b/src/xdpd/management/plugins/rest/xcli
@@ -65,6 +65,8 @@ def list_exec_commands():
 	string+='   exec attach port ge0 dp0\n'
 	string+='   exec create lsi dp1 256 1.3 8\n'
 	string+='   exec create lsi dp1 256 1.2 2 matching-algorithms={"loop", "l2hash"}\n'
+	string+='   exec add controller dp1 tcp:192.168.1.1:6633\n'
+	string+='   exec remove controller dp1 3\n'
 	return string
 
 def usage():

--- a/src/xdpd/management/plugins/rest/xcli
+++ b/src/xdpd/management/plugins/rest/xcli
@@ -42,8 +42,8 @@ def list_show_commands():
 	string+= '   show lsi <lsi_name>\t\t\t - Show LSI information\n'
 	string+= '   show lsi <lsi_name> table <num> flows - Show LSI table <num> flows\n'
 	string+= '   show lsi <lsi_name> group-table\t - List LSI group-table entries\n'
-	string+= '   show lsi <lsi_name> ctls\t - List IDs of LSI\'s Controllers\n'
-	string+= '   show lsi <lsi_name> ctl <ctl-id>\t - Show Controller information\n'
+	string+= '   show lsi <lsi_name> controllers\t - List IDs of LSI\'s Controllers\n'
+	string+= '   show lsi <lsi_name> controller <ctl-id>\t - Show Controller information\n'
 	string+= '   show ports\t\t\t\t - List the available ports in the platform\n'
 	string+= '   show port <port_name>\t\t - Show port information\n'
 	return string

--- a/src/xdpd/management/plugins/rest/xcli
+++ b/src/xdpd/management/plugins/rest/xcli
@@ -56,6 +56,7 @@ def list_exec_commands():
 	string+='                               \t\t\t - Create a logical switch instance\n'
 	string+='   exec destroy lsi <lsi_name> \t\t\t - Destroy a logical switch instance\n'
 	string+='   exec create vlink <lsi1_name> <lsi2_name>\t - Create a virtual link between two logical switch instances\n'
+	string+='   exec add controller <lsi_name> <mode:ip:port>\n'
 	string+="\nExamples:\n\n"
 	string+='   exec port ge0 up\n'
 	string+='   exec attach port ge0 dp0\n'
@@ -170,6 +171,37 @@ def compose_url(url_array):
 	for section in url_array:
 		url +="/"+section
 	return url
+
+##
+# Parse add controller and compose json
+#
+def parse_add_controller(params):
+	obj = {}
+	ctl = obj["ctl"] = {}
+	splitted_vec = params[0].split(':')
+	
+	# Check number of parameters
+	if len(splitted_vec) != 3:
+		raise Exception("Wrong number of parameters. Use protocol:ip:port\nExample tcp:192.0.0.55:6633") 
+
+	if splitted_vec[0] == "tcp":
+		ctl["proto"] = "tcp"
+	elif splitted_vec[0] == "tcp+tls":
+		raise Exception("TLS not yet supported")
+	
+	if splitted_vec[1] == "":
+		#TODO check valid ip (dots, ping?)
+		raise Exception("Invalid IP")
+	else:
+		ctl["ip"] = splitted_vec[1]
+	
+	if splitted_vec[2] == "":
+		raise Exception("Error: Invalid port")
+	else:
+		ctl["port"] = splitted_vec[2]
+
+	return json.dumps(obj)
+
 
 ##
 # Parse create lsi and compose json
@@ -302,6 +334,25 @@ def execute(socket, command, req_confirm=False):
 		elif "destroy" in command:
 			data = ""
 			return rest(socket, compose_url(stripped), data, "DELETE")
+
+		elif "add" in command:
+			data = ""
+			if "controller" in command:
+				data = parse_add_controller(stripped[4:])
+				try: 
+					return rest(socket, compose_url(stripped[:4]), data, "PUT")
+				except Exception as e:	
+					return "error: "+str(e)
+			else:
+				return "Usage: exec add controller ..."
+
+		elif "remove" in command:
+			data = ""
+			if "controller" in command:
+                                return rest(socket. compose_url(stripped), data, "PUT")
+                        else:
+                                return "Usage: exec remove controller ..."
+
 		else:
 			return rest(socket, compose_url(stripped), "", "POST")
 	else:
@@ -478,7 +529,7 @@ class InteractivePrompt(cmd.Cmd):
 			print_less(result)
 
 	def complete_exec(self, text, line, start_index, end_index):
-		exec_cmds = ["port", "attach", "detach", "create", "destroy"]
+		exec_cmds = ["port", "attach", "detach", "create", "destroy", "add", "remove"]
 
 		for cmd in exec_cmds:
 			if cmd in line:

--- a/src/xdpd/management/plugins/rest/xcli
+++ b/src/xdpd/management/plugins/rest/xcli
@@ -340,6 +340,8 @@ def execute(socket, command, req_confirm=False):
 
 		elif "add" in command:
 			data = ""
+			if len(stripped) < 5:
+				return "Usage: exec add controller <lsi_name> <mode:ip:port>"
 			if "controller" in command:
 				data = parse_add_controller(stripped[4:])
 				try: 
@@ -347,14 +349,16 @@ def execute(socket, command, req_confirm=False):
 				except Exception as e:	
 					return "error: "+str(e)
 			else:
-				return "Usage: exec add controller <params>"
+				return "Usage: exec add controller <lsi_name> <mode:ip:port>"
 
 		elif "remove" in command:
 			data = ""
+			if len(stripped) < 4:
+                                return "Usage: exec remove controller <lsi_name> <ctl_id>"
 			if "controller" in command:
                                 return rest(socket, compose_url(stripped), data, "DELETE")
                         else:
-                                return "Usage: exec remove controller <id>"
+                                return "Usage: exec remove controller <lsi_name> <ctl_id>"
 
 		else:
 			return rest(socket, compose_url(stripped), "", "POST")

--- a/src/xdpd/management/snapshots/controller_snapshot.h
+++ b/src/xdpd/management/snapshots/controller_snapshot.h
@@ -1,0 +1,131 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef CONTROLLER_SNAPSHOT_H
+#define CONTROLLER_SNAPSHOT_H 
+
+//#include <iostream> 
+//#include <string> 
+//#include <list> 
+//#include <rofl_datapath.h>
+//#include <rofl/common/caddress.h>
+//#include <rofl/datapath/pipeline/switch_port.h>
+
+/**
+* @file ctl_snapshot.h 
+* @author Victor Alvarez<victor.alvarez (at) bisdn.de>
+*
+* @brief C++ Controller snapshot
+*/
+
+namespace xdpd {
+
+class controller_conn_snapshot {
+public:
+
+	uint64_t id;
+
+	typedef enum {
+		PROTOCOL_UNKNOWN,
+		PROTOCOL_PLAIN,
+		PROTOCOL_SSL,
+	}protocol_type_t;
+
+	/**
+	* Protocol used: Plain/SSL
+	*/
+	protocol_type_t proto_type;
+	
+	/**
+	* IP
+	*/
+	std::string ip;
+
+	/**
+	* Port
+	*/
+	uint64_t port;
+
+ 	//Dumping operator
+	friend std::ostream& operator<<(std::ostream& os, const controller_conn_snapshot& c){
+		os << "id: " << c.id << ", type: ";
+		switch (c.proto_type){
+			case rofl::csocket::SOCKET_TYPE_UNKNOWN:
+                                os << "Unkown";
+                                break;
+                        case rofl::csocket::SOCKET_TYPE_PLAIN:
+                                os << "Plain";
+                                break;
+                        case rofl::csocket::SOCKET_TYPE_OPENSSL:
+                                os << "SSL";
+                                break;
+                        default:
+				assert(0);
+				os << "type error";
+                                break;
+
+		}
+		os << ", IP: " << c.ip << ", port: " << c.port;
+		return os;
+	}
+};
+
+/**
+* @brief C++ controller snapshot 
+* @ingroup cmm_mgmt
+*/
+class controller_snapshot {
+
+public:	
+
+	uint64_t id;
+
+	// Controller Mode
+	typedef enum {
+		CONTROLLER_MODE_MASTER,
+		CONTROLLER_MODE_SLAVE
+	}controller_role_t;
+
+	/**
+	* Role ( Master / slave )
+	*/
+	controller_role_t role;
+
+	/**
+	* Status of the controller
+	*/
+	bool connected;
+
+	/**
+	* List of connections
+	*/
+	std::list<controller_conn_snapshot> conn_list;
+
+ 	//Dumping operator
+	friend std::ostream& operator<<(std::ostream& os, const controller_snapshot& c)
+	{
+		//TODO: Improve output 
+		os << "{ id: " << c.id << ", Channel status: ";
+		if (c.connected){
+			os << " Established";
+		}else{
+			os << " Not established";
+		}
+
+		os << ", Mode: ";
+		if (c.role == CONTROLLER_MODE_MASTER){
+			os << "Master";
+		}else{
+			os << "Slave";
+		}
+		os << "}";
+		return os;
+	}
+
+};
+
+
+}// namespace xdpd
+
+#endif /* CTL_SNAPSHOT_H_ */

--- a/src/xdpd/management/snapshots/controller_snapshot.h
+++ b/src/xdpd/management/snapshots/controller_snapshot.h
@@ -47,25 +47,23 @@ public:
 	*/
 	uint64_t port;
 
+	std::string get_proto_type_str(void) const {
+		switch (this->proto_type){
+			case rofl::csocket::SOCKET_TYPE_UNKNOWN:
+                                return "unkown";
+                        case rofl::csocket::SOCKET_TYPE_PLAIN:
+                                return "plain";
+                        case rofl::csocket::SOCKET_TYPE_OPENSSL:
+                                return "ssl";
+                        default:
+				assert(0);
+				return "type error";
+		}
+	}
  	//Dumping operator
 	friend std::ostream& operator<<(std::ostream& os, const controller_conn_snapshot& c){
 		os << "id: " << c.id << ", type: ";
-		switch (c.proto_type){
-			case rofl::csocket::SOCKET_TYPE_UNKNOWN:
-                                os << "Unkown";
-                                break;
-                        case rofl::csocket::SOCKET_TYPE_PLAIN:
-                                os << "Plain";
-                                break;
-                        case rofl::csocket::SOCKET_TYPE_OPENSSL:
-                                os << "SSL";
-                                break;
-                        default:
-				assert(0);
-				os << "type error";
-                                break;
-
-		}
+		os << c.get_proto_type_str();
 		os << ", IP: " << c.ip << ", port: " << c.port;
 		return os;
 	}
@@ -102,23 +100,26 @@ public:
 	*/
 	std::list<controller_conn_snapshot> conn_list;
 
+	std::string get_status_str(void) const {
+		if (this->connected)
+			return "established";
+		else
+			return "not-established";
+	}
+
+	std::string get_role_str(void) const {
+		if (this->role == CONTROLLER_MODE_MASTER)
+			return "master";
+		else
+			return "slave";
+	}
+
  	//Dumping operator
 	friend std::ostream& operator<<(std::ostream& os, const controller_snapshot& c)
 	{
 		//TODO: Improve output 
-		os << "{ id: " << c.id << ", Channel status: ";
-		if (c.connected){
-			os << " Established";
-		}else{
-			os << " Not established";
-		}
-
-		os << ", Mode: ";
-		if (c.role == CONTROLLER_MODE_MASTER){
-			os << "Master";
-		}else{
-			os << "Slave";
-		}
+		os << "{ id: " << c.id << ", Channel status: " << c.get_status_str();
+		os << ", Mode: " << c.get_role_str();
 		os << "}";
 		return os;
 	}

--- a/src/xdpd/management/snapshots/controller_snapshot.h
+++ b/src/xdpd/management/snapshots/controller_snapshot.h
@@ -5,13 +5,6 @@
 #ifndef CONTROLLER_SNAPSHOT_H
 #define CONTROLLER_SNAPSHOT_H 
 
-//#include <iostream> 
-//#include <string> 
-//#include <list> 
-//#include <rofl_datapath.h>
-//#include <rofl/common/caddress.h>
-//#include <rofl/datapath/pipeline/switch_port.h>
-
 /**
 * @file ctl_snapshot.h 
 * @author Victor Alvarez<victor.alvarez (at) bisdn.de>
@@ -81,6 +74,7 @@ public:
 
 	// Controller Mode
 	typedef enum {
+		CONTROLLER_MODE_EQUAL,
 		CONTROLLER_MODE_MASTER,
 		CONTROLLER_MODE_SLAVE
 	}controller_role_t;
@@ -108,10 +102,16 @@ public:
 	}
 
 	std::string get_role_str(void) const {
-		if (this->role == CONTROLLER_MODE_MASTER)
+		if (this->role == CONTROLLER_MODE_EQUAL)
+			return "equal";
+		else if (this->role == CONTROLLER_MODE_MASTER)
 			return "master";
-		else
+		else if (this->role == CONTROLLER_MODE_SLAVE)
 			return "slave";
+		else{
+			assert(0);
+			return "error";
+		}
 	}
 
  	//Dumping operator

--- a/src/xdpd/management/switch_manager.cc
+++ b/src/xdpd/management/switch_manager.cc
@@ -439,6 +439,21 @@ switch_manager::rpc_list_ctls(uint64_t dpid, std::list<rofl::cctlid>* list){
 
 }
 
+void switch_manager::get_controller_info(uint64_t dpid, uint64_t ctl_id, controller_snapshot& ctl_info){
+
+	pthread_rwlock_wrlock(&switch_manager::rwlock);
+	
+	if (switch_manager::switchs.find(dpid) == switch_manager::switchs.end()){
+		pthread_rwlock_unlock(&switch_manager::rwlock);
+		throw eOfSmDoesNotExist();
+	}
+
+	//Get switch instance
+	openflow_switch* dp = switch_manager::switchs[dpid];
+	dp->get_controller_info(ctl_id, ctl_info);
+
+	pthread_rwlock_unlock(&switch_manager::rwlock);
+}
 
 //
 // Other configuration parameters

--- a/src/xdpd/management/switch_manager.cc
+++ b/src/xdpd/management/switch_manager.cc
@@ -423,7 +423,7 @@ switch_manager::rpc_disconnect_from_ctl(uint64_t dpid, rofl::cctlid ctlid){
 }
 
 void
-switch_manager::rpc_list_ctls(uint64_t dpid, std::list<rofl::cctlid> list){
+switch_manager::rpc_list_ctls(uint64_t dpid, std::list<rofl::cctlid>* list){
 	pthread_rwlock_wrlock(&switch_manager::rwlock);
 	
 	if (switch_manager::switchs.find(dpid) == switch_manager::switchs.end()){

--- a/src/xdpd/management/switch_manager.cc
+++ b/src/xdpd/management/switch_manager.cc
@@ -407,7 +407,7 @@ switch_manager::rpc_connect_to_ctl(uint64_t dpid, enum rofl::csocket::socket_typ
 
 
 void
-switch_manager::rpc_disconnect_from_ctl(uint64_t dpid, enum rofl::csocket::socket_type_t socket_type, cparams const& socket_params){
+switch_manager::rpc_disconnect_from_ctl(uint64_t dpid, rofl::cctlid ctlid){
 
 	pthread_rwlock_wrlock(&switch_manager::rwlock);
 	
@@ -418,7 +418,7 @@ switch_manager::rpc_disconnect_from_ctl(uint64_t dpid, enum rofl::csocket::socke
 
 	//Get switch instance
 	openflow_switch* dp = switch_manager::switchs[dpid];
-	dp->rpc_disconnect_from_ctl(socket_type, socket_params);
+	dp->rpc_disconnect_from_ctl(ctlid);
 	pthread_rwlock_unlock(&switch_manager::rwlock);
 }
 

--- a/src/xdpd/management/switch_manager.cc
+++ b/src/xdpd/management/switch_manager.cc
@@ -422,6 +422,22 @@ switch_manager::rpc_disconnect_from_ctl(uint64_t dpid, rofl::cctlid ctlid){
 	pthread_rwlock_unlock(&switch_manager::rwlock);
 }
 
+void
+switch_manager::rpc_list_ctls(uint64_t dpid, std::list<rofl::cctlid> list){
+	pthread_rwlock_wrlock(&switch_manager::rwlock);
+	
+	if (switch_manager::switchs.find(dpid) == switch_manager::switchs.end()){
+		pthread_rwlock_unlock(&switch_manager::rwlock);
+		throw eOfSmDoesNotExist();
+	}
+
+	//Get switch instance
+	openflow_switch* dp = switch_manager::switchs[dpid];
+	dp->rpc_list_ctls(list);
+	pthread_rwlock_unlock(&switch_manager::rwlock);
+
+}
+
 
 //
 // Other configuration parameters

--- a/src/xdpd/management/switch_manager.cc
+++ b/src/xdpd/management/switch_manager.cc
@@ -389,7 +389,7 @@ void switch_manager::get_switch_group_mods(uint64_t dpid, std::list<openflow_gro
 }
 
 uint64_t
-switch_manager::rpc_connect_to_ctl(uint64_t dpid, enum rofl::csocket::socket_type_t socket_type, cparams const& socket_params){
+switch_manager::connect_to_ctl(uint64_t dpid, enum rofl::csocket::socket_type_t socket_type, cparams const& socket_params){
 
 	pthread_rwlock_wrlock(&switch_manager::rwlock);
 	
@@ -408,7 +408,7 @@ switch_manager::rpc_connect_to_ctl(uint64_t dpid, enum rofl::csocket::socket_typ
 
 
 void
-switch_manager::rpc_disconnect_from_ctl(uint64_t dpid, rofl::cctlid ctlid){
+switch_manager::disconnect_from_ctl(uint64_t dpid, rofl::cctlid ctlid){
 
 	pthread_rwlock_wrlock(&switch_manager::rwlock);
 	
@@ -424,8 +424,8 @@ switch_manager::rpc_disconnect_from_ctl(uint64_t dpid, rofl::cctlid ctlid){
 }
 
 void
-switch_manager::rpc_list_ctls(uint64_t dpid, std::list<rofl::cctlid>* list){
-	pthread_rwlock_wrlock(&switch_manager::rwlock);
+switch_manager::list_ctls(uint64_t dpid, std::list<rofl::cctlid>* list){
+	pthread_rwlock_rdlock(&switch_manager::rwlock);
 	
 	if (switch_manager::switchs.find(dpid) == switch_manager::switchs.end()){
 		pthread_rwlock_unlock(&switch_manager::rwlock);
@@ -441,7 +441,7 @@ switch_manager::rpc_list_ctls(uint64_t dpid, std::list<rofl::cctlid>* list){
 
 void switch_manager::get_controller_info(uint64_t dpid, uint64_t ctl_id, controller_snapshot& ctl_info){
 
-	pthread_rwlock_wrlock(&switch_manager::rwlock);
+	pthread_rwlock_rdlock(&switch_manager::rwlock);
 	
 	if (switch_manager::switchs.find(dpid) == switch_manager::switchs.end()){
 		pthread_rwlock_unlock(&switch_manager::rwlock);

--- a/src/xdpd/management/switch_manager.cc
+++ b/src/xdpd/management/switch_manager.cc
@@ -388,7 +388,7 @@ void switch_manager::get_switch_group_mods(uint64_t dpid, std::list<openflow_gro
 	of1x_destroy_stats_group_msg(group_table_stats);
 }
 
-void
+uint64_t
 switch_manager::rpc_connect_to_ctl(uint64_t dpid, enum rofl::csocket::socket_type_t socket_type, cparams const& socket_params){
 
 	pthread_rwlock_wrlock(&switch_manager::rwlock);
@@ -400,8 +400,9 @@ switch_manager::rpc_connect_to_ctl(uint64_t dpid, enum rofl::csocket::socket_typ
 
 	//Get switch instance
 	openflow_switch* dp = switch_manager::switchs[dpid];
-	dp->rpc_connect_to_ctl(socket_type, socket_params);
+	uint64_t id = dp->rpc_connect_to_ctl(socket_type, socket_params);
 	pthread_rwlock_unlock(&switch_manager::rwlock);
+	return id;
 }
 
 

--- a/src/xdpd/management/switch_manager.h
+++ b/src/xdpd/management/switch_manager.h
@@ -169,17 +169,17 @@ public:
 	/**
 	 * Connect to controller
 	 */
-	static uint64_t rpc_connect_to_ctl(uint64_t dpid, enum rofl::csocket::socket_type_t socket_type, rofl::cparams const& socket_params);
+	static uint64_t connect_to_ctl(uint64_t dpid, enum rofl::csocket::socket_type_t socket_type, rofl::cparams const& socket_params);
 
 	/**
 	 * Disconnect from from controller
 	 */
-	static void rpc_disconnect_from_ctl(uint64_t dpid, rofl::cctlid ctlid);
+	static void disconnect_from_ctl(uint64_t dpid, rofl::cctlid ctlid);
 
 	/**
 	 * List the available controllers ids
 	 */
-	static void rpc_list_ctls(uint64_t dpid, std::list<rofl::cctlid> *list);
+	static void list_ctls(uint64_t dpid, std::list<rofl::cctlid> *list);
 
 	/**
 	 * Get detailed information of a specific controller

--- a/src/xdpd/management/switch_manager.h
+++ b/src/xdpd/management/switch_manager.h
@@ -178,7 +178,7 @@ public:
 	/**
 	 * list the available controllers ids
 	 */
-	static void rpc_list_ctls(uint64_t dpid, std::list<rofl::cctlid> list);
+	static void rpc_list_ctls(uint64_t dpid, std::list<rofl::cctlid> *list);
 
 	//
 	// Other configuration parameters

--- a/src/xdpd/management/switch_manager.h
+++ b/src/xdpd/management/switch_manager.h
@@ -173,7 +173,12 @@ public:
 	/**
 	 * disconnect from from controller
 	 */
-	static void rpc_disconnect_from_ctl(uint64_t dpid, rofl::cctlid ctlid );
+	static void rpc_disconnect_from_ctl(uint64_t dpid, rofl::cctlid ctlid);
+
+	/**
+	 * list the available controllers ids
+	 */
+	static void rpc_list_ctls(uint64_t dpid, std::list<rofl::cctlid> list);
 
 	//
 	// Other configuration parameters

--- a/src/xdpd/management/switch_manager.h
+++ b/src/xdpd/management/switch_manager.h
@@ -168,7 +168,7 @@ public:
 	/**
 	 * connect to controller
 	 */
-	static void rpc_connect_to_ctl(uint64_t dpid, enum rofl::csocket::socket_type_t socket_type, rofl::cparams const& socket_params);
+	static uint64_t rpc_connect_to_ctl(uint64_t dpid, enum rofl::csocket::socket_type_t socket_type, rofl::cparams const& socket_params);
 
 	/**
 	 * disconnect from from controller

--- a/src/xdpd/management/switch_manager.h
+++ b/src/xdpd/management/switch_manager.h
@@ -34,6 +34,7 @@
 #include "snapshots/switch_snapshot.h"
 #include "snapshots/flow_entry_snapshot.h"
 #include "snapshots/group_mod_snapshot.h"
+#include "snapshots/controller_snapshot.h"
 
 /**
 * @file switch_manager.h
@@ -166,19 +167,24 @@ public:
 	//
 
 	/**
-	 * connect to controller
+	 * Connect to controller
 	 */
 	static uint64_t rpc_connect_to_ctl(uint64_t dpid, enum rofl::csocket::socket_type_t socket_type, rofl::cparams const& socket_params);
 
 	/**
-	 * disconnect from from controller
+	 * Disconnect from from controller
 	 */
 	static void rpc_disconnect_from_ctl(uint64_t dpid, rofl::cctlid ctlid);
 
 	/**
-	 * list the available controllers ids
+	 * List the available controllers ids
 	 */
 	static void rpc_list_ctls(uint64_t dpid, std::list<rofl::cctlid> *list);
+
+	/**
+	 * Get detailed information of a specific controller
+	 */
+	static void get_controller_info(uint64_t dpid, uint64_t ctl_id, controller_snapshot& ctl_info);
 
 	//
 	// Other configuration parameters

--- a/src/xdpd/management/switch_manager.h
+++ b/src/xdpd/management/switch_manager.h
@@ -24,6 +24,7 @@
 #include <rofl/common/csocket.h>
 #include <rofl/common/caddress.h>
 #include <rofl/common/croflexception.h>
+#include <rofl/common/cctlid.h>
 
 #include <rofl/datapath/pipeline/common/datapacket.h>
 #include <rofl/datapath/pipeline/openflow/of_switch.h>
@@ -172,7 +173,7 @@ public:
 	/**
 	 * disconnect from from controller
 	 */
-	static void rpc_disconnect_from_ctl(uint64_t dpid, enum rofl::csocket::socket_type_t socket_type, rofl::cparams const& socket_params);
+	static void rpc_disconnect_from_ctl(uint64_t dpid, rofl::cctlid ctlid );
 
 	//
 	// Other configuration parameters

--- a/src/xdpd/openflow/openflow_switch.cc
+++ b/src/xdpd/openflow/openflow_switch.cc
@@ -36,7 +36,13 @@ void openflow_switch::rpc_connect_to_ctl(enum rofl::csocket::socket_type_t socke
 	endpoint->add_ctl(endpoint->get_idle_ctlid(), versionbitmap).connect(rofl::cauxid(0), socket_type, socket_params);
 }
 
-void openflow_switch::rpc_disconnect_from_ctl(enum rofl::csocket::socket_type_t socket_type, cparams const& socket_params){
-	//endpoint->rpc_disconnect_from_ctl(socket_type, socket_params);
+void openflow_switch::rpc_disconnect_from_ctl(rofl::cctlid ctlid){
+	// TODO check for a valid ID
+	//if (endpoint->has_ctl(ctlid)){
+		endpoint->drop_ctl(ctlid);
+	//}
+	//else {
+	//	throw eOfSmNotFound;
+	//}
 }
 

--- a/src/xdpd/openflow/openflow_switch.cc
+++ b/src/xdpd/openflow/openflow_switch.cc
@@ -46,3 +46,6 @@ void openflow_switch::rpc_disconnect_from_ctl(rofl::cctlid ctlid){
 	//}
 }
 
+void openflow_switch::rpc_list_ctls(std::list<rofl::cctlid> ctls_list){
+	endpoint->list_ctls(ctls_list);
+}

--- a/src/xdpd/openflow/openflow_switch.cc
+++ b/src/xdpd/openflow/openflow_switch.cc
@@ -30,13 +30,14 @@ rofl_result_t openflow_switch::notify_port_status_changed(const switch_port_t* p
 /*
 * Connecting and disconnecting from a controller entity
 */
-void openflow_switch::rpc_connect_to_ctl(enum rofl::csocket::socket_type_t socket_type, cparams const& socket_params){
+uint64_t openflow_switch::rpc_connect_to_ctl(enum rofl::csocket::socket_type_t socket_type, cparams const& socket_params){
 	rofl::openflow::cofhello_elem_versionbitmap versionbitmap;
 	versionbitmap.add_ofp_version(version);
-	//rofl::crofctl* ctl = endpoint->add_ctl(endpoint->get_idle_ctlid(), versionbitmap).connect(rofl::cauxid(0), socket_type, socket_params);
-	endpoint->add_ctl(endpoint->get_idle_ctlid(), versionbitmap).connect(rofl::cauxid(0), socket_type, socket_params);
+	rofl::crofctl &ctl = endpoint->add_ctl(endpoint->get_idle_ctlid(), versionbitmap);
+	ctl.connect(rofl::cauxid(0), socket_type, socket_params);
+	//endpoint->add_ctl(endpoint->get_idle_ctlid(), versionbitmap).connect(rofl::cauxid(0), socket_type, socket_params);
 	
-	//return id;
+	return ctl.get_ctlid().get_ctlid();
 }
 
 void openflow_switch::rpc_disconnect_from_ctl(rofl::cctlid ctlid){

--- a/src/xdpd/openflow/openflow_switch.cc
+++ b/src/xdpd/openflow/openflow_switch.cc
@@ -33,7 +33,10 @@ rofl_result_t openflow_switch::notify_port_status_changed(const switch_port_t* p
 void openflow_switch::rpc_connect_to_ctl(enum rofl::csocket::socket_type_t socket_type, cparams const& socket_params){
 	rofl::openflow::cofhello_elem_versionbitmap versionbitmap;
 	versionbitmap.add_ofp_version(version);
+	//rofl::crofctl* ctl = endpoint->add_ctl(endpoint->get_idle_ctlid(), versionbitmap).connect(rofl::cauxid(0), socket_type, socket_params);
 	endpoint->add_ctl(endpoint->get_idle_ctlid(), versionbitmap).connect(rofl::cauxid(0), socket_type, socket_params);
+	
+	//return id;
 }
 
 void openflow_switch::rpc_disconnect_from_ctl(rofl::cctlid ctlid){
@@ -46,6 +49,6 @@ void openflow_switch::rpc_disconnect_from_ctl(rofl::cctlid ctlid){
 	//}
 }
 
-void openflow_switch::rpc_list_ctls(std::list<rofl::cctlid> ctls_list){
+void openflow_switch::rpc_list_ctls(std::list<rofl::cctlid> *ctls_list){
 	endpoint->list_ctls(ctls_list);
 }

--- a/src/xdpd/openflow/openflow_switch.h
+++ b/src/xdpd/openflow/openflow_switch.h
@@ -98,7 +98,7 @@ public:
 	 */
 	virtual void rpc_connect_to_ctl(enum rofl::csocket::socket_type_t socket_type, cparams const& socket_params);
 
-	virtual void rpc_disconnect_from_ctl(enum rofl::csocket::socket_type_t socket_type, cparams const& socket_params);
+	virtual void rpc_disconnect_from_ctl(rofl::cctlid ctlid);
 
 protected:
 	/*

--- a/src/xdpd/openflow/openflow_switch.h
+++ b/src/xdpd/openflow/openflow_switch.h
@@ -22,6 +22,9 @@
 
 namespace xdpd {
 
+// Fwd declaration for controller snapshot
+class controller_snapshot;
+
 /**
 * @brief Version-agnostic abstraction of a complete
 * (logical) OpenFlow switch.
@@ -100,7 +103,12 @@ public:
 
 	virtual void rpc_disconnect_from_ctl(rofl::cctlid ctlid);
 
+	/**
+	 * Getting information about controllers
+	 */
 	virtual void rpc_list_ctls(std::list<rofl::cctlid>*);
+
+	virtual void get_controller_info(uint64_t ctl_id, xdpd::controller_snapshot& ctl_info);
 
 protected:
 	/*

--- a/src/xdpd/openflow/openflow_switch.h
+++ b/src/xdpd/openflow/openflow_switch.h
@@ -96,7 +96,7 @@ public:
 	/**
 	 * Connecting and disconnecting from a controller entity
 	 */
-	virtual void rpc_connect_to_ctl(enum rofl::csocket::socket_type_t socket_type, cparams const& socket_params);
+	virtual uint64_t rpc_connect_to_ctl(enum rofl::csocket::socket_type_t socket_type, cparams const& socket_params);
 
 	virtual void rpc_disconnect_from_ctl(rofl::cctlid ctlid);
 

--- a/src/xdpd/openflow/openflow_switch.h
+++ b/src/xdpd/openflow/openflow_switch.h
@@ -100,6 +100,8 @@ public:
 
 	virtual void rpc_disconnect_from_ctl(rofl::cctlid ctlid);
 
+	virtual void rpc_list_ctls(std::list<rofl::cctlid>);
+
 protected:
 	/*
 	* Pure virtual method that must be implemented by derived classes

--- a/src/xdpd/openflow/openflow_switch.h
+++ b/src/xdpd/openflow/openflow_switch.h
@@ -100,7 +100,7 @@ public:
 
 	virtual void rpc_disconnect_from_ctl(rofl::cctlid ctlid);
 
-	virtual void rpc_list_ctls(std::list<rofl::cctlid>);
+	virtual void rpc_list_ctls(std::list<rofl::cctlid>*);
 
 protected:
 	/*


### PR DESCRIPTION
This PR adds the features of adding, removing and listing controllers to LSIs trough the REST plugin.
Examples on how to use it can be found in the xcli tool.

In order to use the list feature, the API of rofl-common needs to be extended. You may find an extension in vicalro/rofl-common@3d251d6fe5dc4acb3012e114ba2fe823d17aaf67 (branch `list_controllers`)
