### PR TITLE
boost.m4: check boost only with REST plugin

### DIFF
--- a/config/boost.m4
+++ b/config/boost.m4
@@ -110,7 +110,7 @@ AC_LANG_POP([C++])dnl
 # On # success, defines HAVE_BOOST.  On failure, calls the optional
 # ACTION-IF-NOT-FOUND action if one was supplied.
 # Otherwise aborts with an error message.
-AC_DEFUN([BOOST_REQUIRE],
+AC_DEFUN_ONCE([BOOST_REQUIRE],
 [AC_REQUIRE([AC_PROG_CXX])dnl
 AC_REQUIRE([AC_PROG_GREP])dnl
 echo "$as_me: this is boost.m4[]_BOOST_SERIAL" >&AS_MESSAGE_LOG_FD

--- a/config/plugin_rest.m4
+++ b/config/plugin_rest.m4
@@ -1,8 +1,6 @@
 AM_CONDITIONAL([WITH_MGMT_REST], true)
 AC_DEFINE(WITH_MGMT_REST)
 
-AC_REQUIRE([BOOST_REQUIRE])
-
 BOOST_REQUIRE([1.54], [HAVE_BOOST=false])
 if (test "$HAVE_BOOST" = "false"); then
   AC_ERROR("REST management plugin requires Boost")


### PR DESCRIPTION
Commit 17d0ced and PR #79 broke the build system for builds without the
REST plugin. The root cause is apparently is that the new boost.m4,
specifically the MACRO BOOST_REQUIRE uses AC_DEFUN instead of
AC_DEFUN_ONCE as _our_ original boost.m4 (the vanilla in the repo has
always used AC_DEFUN, apparently).

This commit reverts 17d0ced and changes boost.m4 to use AC_DEFUN_ONCE

fixes bisdn/xdpd#94
