### PR TITLE
LSI creation REST call includes the controller address and port

### DIFF
--- a/src/xdpd/management/plugins/rest/sw-controllers.cc
+++ b/src/xdpd/management/plugins/rest/sw-controllers.cc
@@ -251,6 +251,8 @@ void create_lsi(const http::server::request &req, http::server::reply &rep, boos
 	std::string lsi_name = "";
 	unsigned int num_of_tables = 0;
 	int ma_list[OF1X_MAX_FLOWTABLES] = { 0 };
+	std::string controller_hostname = "";
+	unsigned int controller_port = 6653;
 	int reconnect_start_time = 1;
 	enum rofl::csocket::socket_type_t socket_type = rofl::csocket::SOCKET_TYPE_PLAIN;
 	rofl::cparams socket_params = rofl::csocket::get_default_params(socket_type);
@@ -314,6 +316,18 @@ void create_lsi(const http::server::request &req, http::server::reply &rep, boos
 		}catch(...){
 
 		}
+
+		//Controller connection
+		controller_hostname = json_spirit::find_value(obj, "controller-hostname").get_str();
+		controller_port = json_spirit::find_value(obj, "controller-port").get_uint64();
+		socket_params.drop_param("remote-hostname");
+		socket_params.add_param("remote-hostname") = controller_hostname;
+		socket_params.drop_param("remote-port");
+		std::stringstream to_string;
+		to_string << controller_port;
+		socket_params.add_param("remote-port") = to_string.str();
+
+
 	}catch(...){
 		//Something went wrong
 		std::stringstream ss;
@@ -344,6 +358,7 @@ void create_lsi(const http::server::request &req, http::server::reply &rep, boos
 
 	//Create
 	try{
+		std::cout << socket_params;
 
 		switch_manager::create_switch(ver, dpid, lsi_name, num_of_tables, ma_list, reconnect_start_time, socket_type, socket_params);
 	}catch(...){


### PR DESCRIPTION
In the stable release was not possible to create LSI through the REST interface. 
This PR solves the atomic creation of an LSI giving the control connection information is the same call. Could be very fast and useful for large datacentre environments.
