### PR TITLE
gnu-linux: temporally work-around veth NS issues

### DIFF
--- a/src/xdpd/drivers/gnu_linux/src/io/ports/mmap/ioport_mmap.cc
+++ b/src/xdpd/drivers/gnu_linux/src/io/ports/mmap/ioport_mmap.cc
@@ -627,14 +627,14 @@ rofl_result_t ioport_mmap::up() {
 		peer_ifr.ifr_ifindex = peer_id;
 
 		if ((peer_rv = ioctl(peer_sd, SIOCGIFNAME, &peer_ifr)) < 0){
-			close(peer_sd);
-			return ROFL_FAILURE;
+			ROFL_WARN(DRIVER_NAME"[mmap:%s] Warning veth iface peer not detected (running in another namespace?). Offloads will not be disabled. Please, manually disable offloads in both veths!\n", ifr.ifr_name);
+		}else{
+			ROFL_DEBUG(DRIVER_NAME"[mmap:%s] Veth iface detected: peer id = %llu : name %s\n", ifr.ifr_name, peer_id, peer_ifr.ifr_name);
+			
+			//Disable chk offload in both the interface and the link
+			disable_iface_checksum_offloading(peer_sd, peer_ifr);
+			disable_iface_checksum_offloading(sd, ifr);
 		}
-		ROFL_DEBUG(DRIVER_NAME"[mmap:%s] Veth iface detected: peer id = %llu : name %s\n", ifr.ifr_name, peer_id, peer_ifr.ifr_name);
-		
-		//Disable chk offload in both the interface and the link
-		disable_iface_checksum_offloading(peer_sd, peer_ifr);
-		disable_iface_checksum_offloading(sd, ifr);
 		close(peer_sd);
 	}
 #endif	


### PR DESCRIPTION
As discussed in #44, ioport_mmap attempts to disable all
offloads both in the interface and, in case the interface is a
veth pair, the other edge.

However, if the other edge is running in another namespace, the
calls will fail and the port initialization will completely fail
as it is not scheduled in the I/O due to the bring up failure.

This commit works-around this issue by warning the user that
offloads cannot be disabled but continuing with the port UP
command and I/O scheduling.

This is a temporary work around that forces users to manually
disable offloads on BOTH edges. This should be properly fixed by
detecting in which namespace the pair is, and moving temporally
there to disable the offloads, so freeing the user to deal with
these low level details.
