### PR TITLE
dpdk: include librte_mempool as whole archive

### DIFF
--- a/config/hw.m4
+++ b/config/hw.m4
@@ -49,6 +49,7 @@ if ( test "$HW" = "gnu-linux-dpdk");then
 		-Wl,-lrte_pmd_fm10k \
 		-Wl,-lrte_pmd_vmxnet3_uio \
 		-Wl,-lrte_pmd_ring \
+		-Wl,-lrte_mempool \
 		-Wl,--no-whole-archive"
 
 	#Onboard DPDK compilation


### PR DESCRIPTION
this is needed to init the mempool ops natively since the attribute
constructor is lost otherwise.